### PR TITLE
Fix response keys

### DIFF
--- a/lib/ex_aws/parser.ex
+++ b/lib/ex_aws/parser.ex
@@ -55,7 +55,7 @@ defmodule ExAws.ApiGateway.Parser do
 
   defp to_struct(%{} = map, method) do
     struct = @structs |> Map.fetch!(method)
-    [_ | keys] = Map.keys(struct)
+    keys = Map.keys(struct) |> Enum.reject(&(&1 == :__struct__))
 
     map
     |> Map.take(Enum.map(keys, &(Atom.to_string(&1) |> Recase.to_camel())))


### PR DESCRIPTION
```
[_ | keys] = Map.keys(struct)
```

In the above code, we are obtaining the key items to retrieve from the API response using Map.keys.

The structure for the API key creation response is defined as follows:

```
defmodule ExAws.ApiGateway.ApiKey do
  defstruct [
    :id,
    :value,
    :name,
    :customer_id,
    :description,
    :enabled,
    :stage_keys,
    :created_date,
    :last_updated_date
  ]
end
```

When we execute Map.keys on this structure in Erlang 25 and earlier, the result is as follows (the results of Map.keys are sorted):

```
[:__struct__, :created_date, :customer_id, :description, :enabled, :id,
 :last_updated_date, :name, :stage_keys, :value]
```

In Erlang 26 and later, the result is as follows (the results of Map.keys are not sorted):

```
[:enabled, :id, :name, :value, :description, :__struct__, :customer_id,
 :stage_keys, :created_date, :last_updated_date]
```

In the older versions of Erlang, we were able to obtain the key items by excluding the first :__struct__, but in the newer versions, :enabled is excluded from the key items, and we are unable to retrieve its value.